### PR TITLE
Delta write plugin fails for remote filesystems (s3, abfs)

### DIFF
--- a/dbt/adapters/duckdb/plugins/delta.py
+++ b/dbt/adapters/duckdb/plugins/delta.py
@@ -137,7 +137,7 @@ def create_insert_partition(table_path, data, partitions, storage_options):
             f"Overwriting delta table under: {table_path} \nwith partition expr: {partition_expr}"
         )
         write_deltalake(
-            table_path, data, partition_filters=partition_expr, mode="overwrite"
+            table_path, data, partition_filters=partition_expr, mode="overwrite", storage_options=storage_options
         )
     else:
         partitions = [
@@ -146,7 +146,7 @@ def create_insert_partition(table_path, data, partitions, storage_options):
         print(
             f"Creating delta table under: {table_path} \nwith partitions: {partitions}"
         )
-        write_deltalake(table_path, data, partition_by=partitions)
+        write_deltalake(table_path, data, partition_by=partitions, storage_options=storage_options)
 
 
 # Future


### PR DESCRIPTION
storage_options argument allows for the necessary configuration to interact with different storage systems, such as S3 or abfs, by passing the appropriate parameters to the underlying file system.